### PR TITLE
Fix Authserver and Realmserver startup

### DIFF
--- a/Projects/Server/AuthServer/Network/Session.cs
+++ b/Projects/Server/AuthServer/Network/Session.cs
@@ -48,7 +48,7 @@ namespace AuthServer.Network
 
         public void OnConnection(object sender, SocketAsyncEventArgs e)
         {
-            if (e.BytesTransferred < 256 || e.BytesTransferred > 400)
+            if (e.BytesTransferred < 248 || e.BytesTransferred > 400)
             {
                 Log.Network("Wrong initialization packet.");
 

--- a/Sql/Base/MySql/AuthDB.sql
+++ b/Sql/Base/MySql/AuthDB.sql
@@ -45,6 +45,7 @@ CREATE TABLE `Realms` (
   `Port` smallint(5) unsigned NOT NULL DEFAULT '24000',
   `Type` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `Status` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `Population` tinyint(3) unsigned NOT NULL DEFAULT '0'
   `Index` int(10) unsigned NOT NULL DEFAULT '1',
   PRIMARY KEY (`Id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=latin1;


### PR DESCRIPTION
- Fix Authserver rejecting valid initialization packets due to expecting them to be one byte larger
- Fix the 'Realms' table not having a Population column